### PR TITLE
在配置页面加入On/Off按钮用于显示/隐藏应用ID和密钥

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>hqr</groupId>
 	<artifactId>o365</artifactId>
-	<version>1.5.1</version>
+	<version>1.5.2</version>
 	<name>o365</name>
 	<description>Manage office 365</description>
 	<properties>

--- a/src/main/java/com/qq/weixin/mp/aes/AesException.java
+++ b/src/main/java/com/qq/weixin/mp/aes/AesException.java
@@ -1,0 +1,59 @@
+package com.qq.weixin.mp.aes;
+
+@SuppressWarnings("serial")
+public class AesException extends Exception {
+
+	public final static int OK = 0;
+	public final static int ValidateSignatureError = -40001;
+	public final static int ParseXmlError = -40002;
+	public final static int ComputeSignatureError = -40003;
+	public final static int IllegalAesKey = -40004;
+	public final static int ValidateCorpidError = -40005;
+	public final static int EncryptAESError = -40006;
+	public final static int DecryptAESError = -40007;
+	public final static int IllegalBuffer = -40008;
+	//public final static int EncodeBase64Error = -40009;
+	//public final static int DecodeBase64Error = -40010;
+	//public final static int GenReturnXmlError = -40011;
+
+	private int code;
+
+	private static String getMessage(int code) {
+		switch (code) {
+		case ValidateSignatureError:
+			return "签名验证错误";
+		case ParseXmlError:
+			return "xml解析失败";
+		case ComputeSignatureError:
+			return "sha加密生成签名失败";
+		case IllegalAesKey:
+			return "SymmetricKey非法";
+		case ValidateCorpidError:
+			return "corpid校验失败";
+		case EncryptAESError:
+			return "aes加密失败";
+		case DecryptAESError:
+			return "aes解密失败";
+		case IllegalBuffer:
+			return "解密后得到的buffer非法";
+//		case EncodeBase64Error:
+//			return "base64加密错误";
+//		case DecodeBase64Error:
+//			return "base64解密错误";
+//		case GenReturnXmlError:
+//			return "xml生成失败";
+		default:
+			return null; // cannot be
+		}
+	}
+
+	public int getCode() {
+		return code;
+	}
+
+	AesException(int code) {
+		super(getMessage(code));
+		this.code = code;
+	}
+
+}

--- a/src/main/java/com/qq/weixin/mp/aes/ByteGroup.java
+++ b/src/main/java/com/qq/weixin/mp/aes/ByteGroup.java
@@ -1,0 +1,26 @@
+package com.qq.weixin.mp.aes;
+
+import java.util.ArrayList;
+
+class ByteGroup {
+	ArrayList<Byte> byteContainer = new ArrayList<Byte>();
+
+	public byte[] toBytes() {
+		byte[] bytes = new byte[byteContainer.size()];
+		for (int i = 0; i < byteContainer.size(); i++) {
+			bytes[i] = byteContainer.get(i);
+		}
+		return bytes;
+	}
+
+	public ByteGroup addBytes(byte[] bytes) {
+		for (byte b : bytes) {
+			byteContainer.add(b);
+		}
+		return this;
+	}
+
+	public int size() {
+		return byteContainer.size();
+	}
+}

--- a/src/main/java/com/qq/weixin/mp/aes/PKCS7Encoder.java
+++ b/src/main/java/com/qq/weixin/mp/aes/PKCS7Encoder.java
@@ -1,0 +1,67 @@
+/**
+ * 对企业微信发送给企业后台的消息加解密示例代码.
+ * 
+ * @copyright Copyright (c) 1998-2014 Tencent Inc.
+ */
+
+// ------------------------------------------------------------------------
+
+package com.qq.weixin.mp.aes;
+
+import java.nio.charset.Charset;
+import java.util.Arrays;
+
+/**
+ * 提供基于PKCS7算法的加解密接口.
+ */
+class PKCS7Encoder {
+	static Charset CHARSET = Charset.forName("utf-8");
+	static int BLOCK_SIZE = 32;
+
+	/**
+	 * 获得对明文进行补位填充的字节.
+	 * 
+	 * @param count 需要进行填充补位操作的明文字节个数
+	 * @return 补齐用的字节数组
+	 */
+	static byte[] encode(int count) {
+		// 计算需要填充的位数
+		int amountToPad = BLOCK_SIZE - (count % BLOCK_SIZE);
+		if (amountToPad == 0) {
+			amountToPad = BLOCK_SIZE;
+		}
+		// 获得补位所用的字符
+		char padChr = chr(amountToPad);
+		String tmp = new String();
+		for (int index = 0; index < amountToPad; index++) {
+			tmp += padChr;
+		}
+		return tmp.getBytes(CHARSET);
+	}
+
+	/**
+	 * 删除解密后明文的补位字符
+	 * 
+	 * @param decrypted 解密后的明文
+	 * @return 删除补位字符后的明文
+	 */
+	static byte[] decode(byte[] decrypted) {
+		int pad = (int) decrypted[decrypted.length - 1];
+		if (pad < 1 || pad > 32) {
+			pad = 0;
+		}
+		return Arrays.copyOfRange(decrypted, 0, decrypted.length - pad);
+	}
+
+	/**
+	 * 将数字转化成ASCII码对应的字符，用于对明文进行补码
+	 * 
+	 * @param a 需要转化的数字
+	 * @return 转化得到的字符
+	 */
+	static char chr(int a) {
+		byte target = (byte) (a & 0xFF);
+		return (char) target;
+	}
+
+}

--- a/src/main/java/com/qq/weixin/mp/aes/SHA1.java
+++ b/src/main/java/com/qq/weixin/mp/aes/SHA1.java
@@ -1,0 +1,61 @@
+/**
+ * 对企业微信发送给企业后台的消息加解密示例代码.
+ * 
+ * @copyright Copyright (c) 1998-2014 Tencent Inc.
+ */
+
+// ------------------------------------------------------------------------
+
+package com.qq.weixin.mp.aes;
+
+import java.security.MessageDigest;
+import java.util.Arrays;
+
+/**
+ * SHA1 class
+ *
+ * 计算消息签名接口.
+ */
+class SHA1 {
+
+	/**
+	 * 用SHA1算法生成安全签名
+	 * @param token 票据
+	 * @param timestamp 时间戳
+	 * @param nonce 随机字符串
+	 * @param encrypt 密文
+	 * @return 安全签名
+	 * @throws AesException 
+	 */
+	public static String getSHA1(String token, String timestamp, String nonce, String encrypt) throws AesException
+			  {
+		try {
+			String[] array = new String[] { token, timestamp, nonce, encrypt };
+			StringBuffer sb = new StringBuffer();
+			// 字符串排序
+			Arrays.sort(array);
+			for (int i = 0; i < 4; i++) {
+				sb.append(array[i]);
+			}
+			String str = sb.toString();
+			// SHA1签名生成
+			MessageDigest md = MessageDigest.getInstance("SHA-1");
+			md.update(str.getBytes());
+			byte[] digest = md.digest();
+
+			StringBuffer hexstr = new StringBuffer();
+			String shaHex = "";
+			for (int i = 0; i < digest.length; i++) {
+				shaHex = Integer.toHexString(digest[i] & 0xFF);
+				if (shaHex.length() < 2) {
+					hexstr.append(0);
+				}
+				hexstr.append(shaHex);
+			}
+			return hexstr.toString();
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new AesException(AesException.ComputeSignatureError);
+		}
+	}
+}

--- a/src/main/java/com/qq/weixin/mp/aes/WXBizMsgCrypt.java
+++ b/src/main/java/com/qq/weixin/mp/aes/WXBizMsgCrypt.java
@@ -1,0 +1,289 @@
+/**
+ * 对企业微信发送给企业后台的消息加解密示例代码.
+ * 
+ * @copyright Copyright (c) 1998-2014 Tencent Inc.
+ */
+
+// ------------------------------------------------------------------------
+
+/**
+ * 针对org.apache.commons.codec.binary.Base64，
+ * 需要导入架包commons-codec-1.9（或commons-codec-1.8等其他版本）
+ * 官方下载地址：http://commons.apache.org/proper/commons-codec/download_codec.cgi
+ */
+package com.qq.weixin.mp.aes;
+
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Random;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.apache.commons.codec.binary.Base64;
+
+/**
+ * 提供接收和推送给企业微信消息的加解密接口(UTF8编码的字符串).
+ * <ol>
+ * 	<li>第三方回复加密消息给企业微信</li>
+ * 	<li>第三方收到企业微信发送的消息，验证消息的安全性，并对消息进行解密。</li>
+ * </ol>
+ * 说明：异常java.security.InvalidKeyException:illegal Key Size的解决方案
+ * <ol>
+ * 	<li>在官方网站下载JCE无限制权限策略文件（JDK7的下载地址：
+ *      http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html</li>
+ * 	<li>下载后解压，可以看到local_policy.jar和US_export_policy.jar以及readme.txt</li>
+ * 	<li>如果安装了JRE，将两个jar文件放到%JRE_HOME%\lib\security目录下覆盖原来的文件</li>
+ * 	<li>如果安装了JDK，将两个jar文件放到%JDK_HOME%\jre\lib\security目录下覆盖原来文件</li>
+ * </ol>
+ */
+public class WXBizMsgCrypt {
+	static Charset CHARSET = Charset.forName("utf-8");
+	Base64 base64 = new Base64();
+	byte[] aesKey;
+	String token;
+	String receiveid;
+
+	/**
+	 * 构造函数
+	 * @param token 企业微信后台，开发者设置的token
+	 * @param encodingAesKey 企业微信后台，开发者设置的EncodingAESKey
+	 * @param receiveid, 不同场景含义不同，详见文档
+	 * 
+	 * @throws AesException 执行失败，请查看该异常的错误码和具体的错误信息
+	 */
+	public WXBizMsgCrypt(String token, String encodingAesKey, String receiveid) throws AesException {
+		if (encodingAesKey.length() != 43) {
+			throw new AesException(AesException.IllegalAesKey);
+		}
+
+		this.token = token;
+		this.receiveid = receiveid;
+		aesKey = Base64.decodeBase64(encodingAesKey + "=");
+	}
+
+	// 生成4个字节的网络字节序
+	byte[] getNetworkBytesOrder(int sourceNumber) {
+		byte[] orderBytes = new byte[4];
+		orderBytes[3] = (byte) (sourceNumber & 0xFF);
+		orderBytes[2] = (byte) (sourceNumber >> 8 & 0xFF);
+		orderBytes[1] = (byte) (sourceNumber >> 16 & 0xFF);
+		orderBytes[0] = (byte) (sourceNumber >> 24 & 0xFF);
+		return orderBytes;
+	}
+
+	// 还原4个字节的网络字节序
+	int recoverNetworkBytesOrder(byte[] orderBytes) {
+		int sourceNumber = 0;
+		for (int i = 0; i < 4; i++) {
+			sourceNumber <<= 8;
+			sourceNumber |= orderBytes[i] & 0xff;
+		}
+		return sourceNumber;
+	}
+
+	// 随机生成16位字符串
+	String getRandomStr() {
+		String base = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+		Random random = new Random();
+		StringBuffer sb = new StringBuffer();
+		for (int i = 0; i < 16; i++) {
+			int number = random.nextInt(base.length());
+			sb.append(base.charAt(number));
+		}
+		return sb.toString();
+	}
+
+	/**
+	 * 对明文进行加密.
+	 * 
+	 * @param text 需要加密的明文
+	 * @return 加密后base64编码的字符串
+	 * @throws AesException aes加密失败
+	 */
+	String encrypt(String randomStr, String text) throws AesException {
+		ByteGroup byteCollector = new ByteGroup();
+		byte[] randomStrBytes = randomStr.getBytes(CHARSET);
+		byte[] textBytes = text.getBytes(CHARSET);
+		byte[] networkBytesOrder = getNetworkBytesOrder(textBytes.length);
+		byte[] receiveidBytes = receiveid.getBytes(CHARSET);
+
+		// randomStr + networkBytesOrder + text + receiveid
+		byteCollector.addBytes(randomStrBytes);
+		byteCollector.addBytes(networkBytesOrder);
+		byteCollector.addBytes(textBytes);
+		byteCollector.addBytes(receiveidBytes);
+
+		// ... + pad: 使用自定义的填充方式对明文进行补位填充
+		byte[] padBytes = PKCS7Encoder.encode(byteCollector.size());
+		byteCollector.addBytes(padBytes);
+
+		// 获得最终的字节流, 未加密
+		byte[] unencrypted = byteCollector.toBytes();
+
+		try {
+			// 设置加密模式为AES的CBC模式
+			Cipher cipher = Cipher.getInstance("AES/CBC/NoPadding");
+			SecretKeySpec keySpec = new SecretKeySpec(aesKey, "AES");
+			IvParameterSpec iv = new IvParameterSpec(aesKey, 0, 16);
+			cipher.init(Cipher.ENCRYPT_MODE, keySpec, iv);
+
+			// 加密
+			byte[] encrypted = cipher.doFinal(unencrypted);
+
+			// 使用BASE64对加密后的字符串进行编码
+			String base64Encrypted = base64.encodeToString(encrypted);
+
+			return base64Encrypted;
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new AesException(AesException.EncryptAESError);
+		}
+	}
+
+	/**
+	 * 对密文进行解密.
+	 * 
+	 * @param text 需要解密的密文
+	 * @return 解密得到的明文
+	 * @throws AesException aes解密失败
+	 */
+	String decrypt(String text) throws AesException {
+		byte[] original;
+		try {
+			// 设置解密模式为AES的CBC模式
+			Cipher cipher = Cipher.getInstance("AES/CBC/NoPadding");
+			SecretKeySpec key_spec = new SecretKeySpec(aesKey, "AES");
+			IvParameterSpec iv = new IvParameterSpec(Arrays.copyOfRange(aesKey, 0, 16));
+			cipher.init(Cipher.DECRYPT_MODE, key_spec, iv);
+
+			// 使用BASE64对密文进行解码
+			byte[] encrypted = Base64.decodeBase64(text);
+
+			// 解密
+			original = cipher.doFinal(encrypted);
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new AesException(AesException.DecryptAESError);
+		}
+
+		String xmlContent, from_receiveid;
+		try {
+			// 去除补位字符
+			byte[] bytes = PKCS7Encoder.decode(original);
+
+			// 分离16位随机字符串,网络字节序和receiveid
+			byte[] networkOrder = Arrays.copyOfRange(bytes, 16, 20);
+
+			int xmlLength = recoverNetworkBytesOrder(networkOrder);
+
+			xmlContent = new String(Arrays.copyOfRange(bytes, 20, 20 + xmlLength), CHARSET);
+			from_receiveid = new String(Arrays.copyOfRange(bytes, 20 + xmlLength, bytes.length),
+					CHARSET);
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new AesException(AesException.IllegalBuffer);
+		}
+
+		// receiveid不相同的情况
+		if (!from_receiveid.equals(receiveid)) {
+			throw new AesException(AesException.ValidateCorpidError);
+		}
+		return xmlContent;
+
+	}
+
+	/**
+	 * 将企业微信回复用户的消息加密打包.
+	 * <ol>
+	 * 	<li>对要发送的消息进行AES-CBC加密</li>
+	 * 	<li>生成安全签名</li>
+	 * 	<li>将消息密文和安全签名打包成xml格式</li>
+	 * </ol>
+	 * 
+	 * @param replyMsg 企业微信待回复用户的消息，xml格式的字符串
+	 * @param timeStamp 时间戳，可以自己生成，也可以用URL参数的timestamp
+	 * @param nonce 随机串，可以自己生成，也可以用URL参数的nonce
+	 * 
+	 * @return 加密后的可以直接回复用户的密文，包括msg_signature, timestamp, nonce, encrypt的xml格式的字符串
+	 * @throws AesException 执行失败，请查看该异常的错误码和具体的错误信息
+	 */
+	public String EncryptMsg(String replyMsg, String timeStamp, String nonce) throws AesException {
+		// 加密
+		String encrypt = encrypt(getRandomStr(), replyMsg);
+
+		// 生成安全签名
+		if (timeStamp == "") {
+			timeStamp = Long.toString(System.currentTimeMillis());
+		}
+
+		String signature = SHA1.getSHA1(token, timeStamp, nonce, encrypt);
+
+		// System.out.println("发送给平台的签名是: " + signature[1].toString());
+		// 生成发送的xml
+		String result = XMLParse.generate(encrypt, signature, timeStamp, nonce);
+		return result;
+	}
+
+	/**
+	 * 检验消息的真实性，并且获取解密后的明文.
+	 * <ol>
+	 * 	<li>利用收到的密文生成安全签名，进行签名验证</li>
+	 * 	<li>若验证通过，则提取xml中的加密消息</li>
+	 * 	<li>对消息进行解密</li>
+	 * </ol>
+	 * 
+	 * @param msgSignature 签名串，对应URL参数的msg_signature
+	 * @param timeStamp 时间戳，对应URL参数的timestamp
+	 * @param nonce 随机串，对应URL参数的nonce
+	 * @param postData 密文，对应POST请求的数据
+	 * 
+	 * @return 解密后的原文
+	 * @throws AesException 执行失败，请查看该异常的错误码和具体的错误信息
+	 */
+	public String DecryptMsg(String msgSignature, String timeStamp, String nonce, String postData)
+			throws AesException {
+
+		// 密钥，公众账号的app secret
+		// 提取密文
+		Object[] encrypt = XMLParse.extract(postData);
+
+		// 验证安全签名
+		String signature = SHA1.getSHA1(token, timeStamp, nonce, encrypt[1].toString());
+
+		// 和URL中的签名比较是否相等
+		// System.out.println("第三方收到URL中的签名：" + msg_sign);
+		// System.out.println("第三方校验签名：" + signature);
+		if (!signature.equals(msgSignature)) {
+			throw new AesException(AesException.ValidateSignatureError);
+		}
+
+		// 解密
+		String result = decrypt(encrypt[1].toString());
+		return result;
+	}
+
+	/**
+	 * 验证URL
+	 * @param msgSignature 签名串，对应URL参数的msg_signature
+	 * @param timeStamp 时间戳，对应URL参数的timestamp
+	 * @param nonce 随机串，对应URL参数的nonce
+	 * @param echoStr 随机串，对应URL参数的echostr
+	 * 
+	 * @return 解密之后的echostr
+	 * @throws AesException 执行失败，请查看该异常的错误码和具体的错误信息
+	 */
+	public String VerifyURL(String msgSignature, String timeStamp, String nonce, String echoStr)
+			throws AesException {
+		String signature = SHA1.getSHA1(token, timeStamp, nonce, echoStr);
+
+		if (!signature.equals(msgSignature)) {
+			throw new AesException(AesException.ValidateSignatureError);
+		}
+
+		String result = decrypt(echoStr);
+		return result;
+	}
+
+}

--- a/src/main/java/com/qq/weixin/mp/aes/XMLParse.java
+++ b/src/main/java/com/qq/weixin/mp/aes/XMLParse.java
@@ -1,0 +1,104 @@
+/**
+ * 对企业微信发送给企业后台的消息加解密示例代码.
+ * 
+ * @copyright Copyright (c) 1998-2014 Tencent Inc.
+ */
+
+// ------------------------------------------------------------------------
+
+package com.qq.weixin.mp.aes;
+
+import java.io.StringReader;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+/**
+ * XMLParse class
+ *
+ * 提供提取消息格式中的密文及生成回复消息格式的接口.
+ */
+class XMLParse {
+
+	/**
+	 * 提取出xml数据包中的加密消息
+	 * @param xmltext 待提取的xml字符串
+	 * @return 提取出的加密消息字符串
+	 * @throws AesException 
+	 */
+	public static Object[] extract(String xmltext) throws AesException     {
+		Object[] result = new Object[3];
+		try {
+			DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+			
+			String FEATURE = null;
+			// This is the PRIMARY defense. If DTDs (doctypes) are disallowed, almost all XML entity attacks are prevented
+			// Xerces 2 only - http://xerces.apache.org/xerces2-j/features.html#disallow-doctype-decl
+			FEATURE = "http://apache.org/xml/features/disallow-doctype-decl";
+			dbf.setFeature(FEATURE, true);
+			
+			// If you can't completely disable DTDs, then at least do the following:
+			// Xerces 1 - http://xerces.apache.org/xerces-j/features.html#external-general-entities
+			// Xerces 2 - http://xerces.apache.org/xerces2-j/features.html#external-general-entities
+			// JDK7+ - http://xml.org/sax/features/external-general-entities 
+			FEATURE = "http://xml.org/sax/features/external-general-entities";
+			dbf.setFeature(FEATURE, false);
+			
+			// Xerces 1 - http://xerces.apache.org/xerces-j/features.html#external-parameter-entities
+			// Xerces 2 - http://xerces.apache.org/xerces2-j/features.html#external-parameter-entities
+			// JDK7+ - http://xml.org/sax/features/external-parameter-entities 
+			FEATURE = "http://xml.org/sax/features/external-parameter-entities";
+			dbf.setFeature(FEATURE, false);
+			
+			// Disable external DTDs as well
+			FEATURE = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
+			dbf.setFeature(FEATURE, false);
+			
+			// and these as well, per Timothy Morgan's 2014 paper: "XML Schema, DTD, and Entity Attacks"
+			dbf.setXIncludeAware(false);
+			dbf.setExpandEntityReferences(false);
+			
+			// And, per Timothy Morgan: "If for some reason support for inline DOCTYPEs are a requirement, then 
+			// ensure the entity settings are disabled (as shown above) and beware that SSRF attacks
+			// (http://cwe.mitre.org/data/definitions/918.html) and denial 
+			// of service attacks (such as billion laughs or decompression bombs via "jar:") are a risk."
+			
+			// remaining parser logic
+			DocumentBuilder db = dbf.newDocumentBuilder();
+			StringReader sr = new StringReader(xmltext);
+			InputSource is = new InputSource(sr);
+			Document document = db.parse(is);
+
+			Element root = document.getDocumentElement();
+			NodeList nodelist1 = root.getElementsByTagName("Encrypt");
+			result[0] = 0;
+			result[1] = nodelist1.item(0).getTextContent();
+			return result;
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new AesException(AesException.ParseXmlError);
+		}
+	}
+
+	/**
+	 * 生成xml消息
+	 * @param encrypt 加密后的消息密文
+	 * @param signature 安全签名
+	 * @param timestamp 时间戳
+	 * @param nonce 随机字符串
+	 * @return 生成的xml字符串
+	 */
+	public static String generate(String encrypt, String signature, String timestamp, String nonce) {
+
+		String format = "<xml>\n" + "<Encrypt><![CDATA[%1$s]]></Encrypt>\n"
+				+ "<MsgSignature><![CDATA[%2$s]]></MsgSignature>\n"
+				+ "<TimeStamp>%3$s</TimeStamp>\n" + "<Nonce><![CDATA[%4$s]]></Nonce>\n" + "</xml>";
+		return String.format(format, encrypt, signature, timestamp, nonce);
+
+	}
+}

--- a/src/main/java/hqr/o365/config/SecurityConfig.java
+++ b/src/main/java/hqr/o365/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 				.failureUrl("/loginError").permitAll().and();
 		http.authorizeRequests() // 授权配置
 				// 无需权限访问
-				.antMatchers("/h2/**", "/*.svg", "/jquery-easyui-1.9.14/**", "/", "/index.html", "/loginPage","/reg","/reg.html","/chkUserId").permitAll()
+				.antMatchers("/h2/**", "/*.svg", "/jquery-easyui-1.9.14/**", "/", "/index.html", "/loginPage","/reg","/reg.html","/chkUserId","/callback").permitAll()
 				// 其他接口需要登录后才能访问
 				.anyRequest().authenticated().and();
 	}

--- a/src/main/java/hqr/o365/ctrl/IndexCtrl.java
+++ b/src/main/java/hqr/o365/ctrl/IndexCtrl.java
@@ -35,7 +35,7 @@ public class IndexCtrl {
 	
 	@ResponseBody
 	@RequestMapping(value = {"/callback"})
-	public String callback(HttpServletRequest request, @RequestBody String body ){
+	public String callback(HttpServletRequest request, @RequestBody(required=false) String body ){
 		return cbs.handleCallBack(request, body);
 	}
 	

--- a/src/main/java/hqr/o365/ctrl/IndexCtrl.java
+++ b/src/main/java/hqr/o365/ctrl/IndexCtrl.java
@@ -1,9 +1,24 @@
 package hqr.o365.ctrl;
 
+import java.io.StringReader;
+
 import javax.servlet.http.HttpServletRequest;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.Element;
+import org.xml.sax.InputSource;
+
+import com.qq.weixin.mp.aes.AesException;
+import com.qq.weixin.mp.aes.WXBizMsgCrypt;
+
 import hqr.o365.service.GetGlobalInd;
 
 @Controller
@@ -25,4 +40,61 @@ public class IndexCtrl {
 			return "login";
 		}
 	}
+	
+	@ResponseBody
+	@RequestMapping(value = {"/callback"})
+	public String callback(HttpServletRequest request, @RequestBody String body ){
+		//GET -> bind , POST -> get msg
+		String method = request.getMethod();
+		
+		String sToken = "A0cQOwx1vcTHPWJOiyUipjvk2JDw3";
+		String sCorpID = "ww13a3890a2c0815e3";
+		String sEncodingAESKey = "rrtr5fIcKnyXwm3OOCLoarvrxT1EJ6PTFU3cBnaOknN";
+		
+		if("GET".equals(method)) {
+			String sVerifyMsgSig = request.getParameter("msg_signature");
+			String sVerifyTimeStamp = request.getParameter("timestamp");
+			String sVerifyNonce = request.getParameter("nonce");
+			String sVerifyEchoStr = request.getParameter("echostr");
+
+			String sEchoStr = "";
+			try {
+				WXBizMsgCrypt wxcpt = new WXBizMsgCrypt(sToken, sEncodingAESKey, sCorpID);
+				sEchoStr = wxcpt.VerifyURL(sVerifyMsgSig, sVerifyTimeStamp, sVerifyNonce, sVerifyEchoStr);
+			} catch (AesException e) {
+				e.printStackTrace();
+			}
+			return sEchoStr;
+		}
+		else if("POST".equals(method)) {
+			String sReqMsgSig = request.getParameter("msg_signature");
+			String sReqTimeStamp = request.getParameter("timestamp");
+			String sReqNonce = request.getParameter("nonce");
+			String sReqData = body;
+			try {
+				WXBizMsgCrypt wxcpt = new WXBizMsgCrypt(sToken, sEncodingAESKey, sCorpID);
+				String sMsg = wxcpt.DecryptMsg(sReqMsgSig, sReqTimeStamp, sReqNonce, sReqData);
+				
+				DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+				StringReader sr = new StringReader(sMsg);
+				Document document = db.parse(new InputSource(sr));
+
+				Element root = document.getDocumentElement();
+				NodeList nodelist1 = root.getElementsByTagName("FromUserName");
+				String sender = nodelist1.item(0).getTextContent();
+				NodeList nodelist2 = root.getElementsByTagName("Content");
+				String content = nodelist2.item(0).getTextContent();
+				System.out.println("Sender is " + sender);
+				System.out.println("Content is " + content);
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+			return "ok";
+		}
+		else {
+			System.out.println("Not support method:"+ method);
+			return "Not support method:"+ method;
+		}
+	}
+	
 }

--- a/src/main/java/hqr/o365/ctrl/IndexCtrl.java
+++ b/src/main/java/hqr/o365/ctrl/IndexCtrl.java
@@ -1,24 +1,13 @@
 package hqr.o365.ctrl;
 
-import java.io.StringReader;
-
 import javax.servlet.http.HttpServletRequest;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.w3c.dom.Document;
-import org.w3c.dom.NodeList;
-import org.w3c.dom.Element;
-import org.xml.sax.InputSource;
-
-import com.qq.weixin.mp.aes.AesException;
-import com.qq.weixin.mp.aes.WXBizMsgCrypt;
-
+import hqr.o365.service.CallBackService;
 import hqr.o365.service.GetGlobalInd;
 
 @Controller
@@ -26,6 +15,9 @@ public class IndexCtrl {
 	
 	@Autowired
 	private GetGlobalInd ggl;
+	
+	@Autowired
+	private CallBackService cbs;
 	
 	@RequestMapping(value = {"/","/index.html"})
 	public String index(HttpServletRequest request) {
@@ -44,57 +36,7 @@ public class IndexCtrl {
 	@ResponseBody
 	@RequestMapping(value = {"/callback"})
 	public String callback(HttpServletRequest request, @RequestBody String body ){
-		//GET -> bind , POST -> get msg
-		String method = request.getMethod();
-		
-		String sToken = "A0cQOwx1vcTHPWJOiyUipjvk2JDw3";
-		String sCorpID = "ww13a3890a2c0815e3";
-		String sEncodingAESKey = "rrtr5fIcKnyXwm3OOCLoarvrxT1EJ6PTFU3cBnaOknN";
-		
-		if("GET".equals(method)) {
-			String sVerifyMsgSig = request.getParameter("msg_signature");
-			String sVerifyTimeStamp = request.getParameter("timestamp");
-			String sVerifyNonce = request.getParameter("nonce");
-			String sVerifyEchoStr = request.getParameter("echostr");
-
-			String sEchoStr = "";
-			try {
-				WXBizMsgCrypt wxcpt = new WXBizMsgCrypt(sToken, sEncodingAESKey, sCorpID);
-				sEchoStr = wxcpt.VerifyURL(sVerifyMsgSig, sVerifyTimeStamp, sVerifyNonce, sVerifyEchoStr);
-			} catch (AesException e) {
-				e.printStackTrace();
-			}
-			return sEchoStr;
-		}
-		else if("POST".equals(method)) {
-			String sReqMsgSig = request.getParameter("msg_signature");
-			String sReqTimeStamp = request.getParameter("timestamp");
-			String sReqNonce = request.getParameter("nonce");
-			String sReqData = body;
-			try {
-				WXBizMsgCrypt wxcpt = new WXBizMsgCrypt(sToken, sEncodingAESKey, sCorpID);
-				String sMsg = wxcpt.DecryptMsg(sReqMsgSig, sReqTimeStamp, sReqNonce, sReqData);
-				
-				DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-				StringReader sr = new StringReader(sMsg);
-				Document document = db.parse(new InputSource(sr));
-
-				Element root = document.getDocumentElement();
-				NodeList nodelist1 = root.getElementsByTagName("FromUserName");
-				String sender = nodelist1.item(0).getTextContent();
-				NodeList nodelist2 = root.getElementsByTagName("Content");
-				String content = nodelist2.item(0).getTextContent();
-				System.out.println("Sender is " + sender);
-				System.out.println("Content is " + content);
-			} catch (Exception e) {
-				e.printStackTrace();
-			}
-			return "ok";
-		}
-		else {
-			System.out.println("Not support method:"+ method);
-			return "Not support method:"+ method;
-		}
+		return cbs.handleCallBack(request, body);
 	}
 	
 }

--- a/src/main/java/hqr/o365/service/CallBackService.java
+++ b/src/main/java/hqr/o365/service/CallBackService.java
@@ -1,0 +1,120 @@
+package hqr.o365.service;
+
+import java.io.StringReader;
+import java.util.Optional;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+import com.qq.weixin.mp.aes.AesException;
+import com.qq.weixin.mp.aes.WXBizMsgCrypt;
+
+import hqr.o365.dao.TaMasterCdRepo;
+import hqr.o365.domain.TaMasterCd;
+
+@Service
+public class CallBackService {
+
+	@Autowired
+	private TaMasterCdRepo tmc;
+	
+	public String handleCallBack(HttpServletRequest request, String body) {
+		//GET -> bind , POST -> get msg
+		String method = request.getMethod();
+		String result = "";
+		
+		Optional<TaMasterCd> opt0 = tmc.findById("WX_CALLBACK_IND");
+		if(opt0.isPresent()) {
+			String indicator = opt0.get().getCd();
+			if("Y".equals(indicator)) {
+				Optional<TaMasterCd> opt1 = tmc.findById("WX_CALLBACK_TOKEN");
+				Optional<TaMasterCd> opt2 = tmc.findById("WX_CORPID");
+				Optional<TaMasterCd> opt3 =tmc.findById("WX_CALLBACK_AESKEY");
+				
+				if(opt1.isPresent()&&opt2.isPresent()&&opt3.isPresent()) {
+					
+					String sToken = opt1.get().getCd();
+					String sCorpID = opt2.get().getCd();
+					String sEncodingAESKey = opt3.get().getCd();
+					
+					if("GET".equals(method)) {
+						String sVerifyMsgSig = request.getParameter("msg_signature");
+						String sVerifyTimeStamp = request.getParameter("timestamp");
+						String sVerifyNonce = request.getParameter("nonce");
+						String sVerifyEchoStr = request.getParameter("echostr");
+
+						try {
+							WXBizMsgCrypt wxcpt = new WXBizMsgCrypt(sToken, sEncodingAESKey, sCorpID);
+							result = wxcpt.VerifyURL(sVerifyMsgSig, sVerifyTimeStamp, sVerifyNonce, sVerifyEchoStr);
+						} catch (AesException e) {
+							e.printStackTrace();
+						}
+					}
+					else if("POST".equals(method)) {
+						String sReqMsgSig = request.getParameter("msg_signature");
+						String sReqTimeStamp = request.getParameter("timestamp");
+						String sReqNonce = request.getParameter("nonce");
+						String sReqData = body;
+						try {
+							WXBizMsgCrypt wxcpt = new WXBizMsgCrypt(sToken, sEncodingAESKey, sCorpID);
+							String sMsg = wxcpt.DecryptMsg(sReqMsgSig, sReqTimeStamp, sReqNonce, sReqData);
+							
+							DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+							StringReader sr = new StringReader(sMsg);
+							Document document = db.parse(new InputSource(sr));
+
+							Element root = document.getDocumentElement();
+							NodeList nodelist1 = root.getElementsByTagName("FromUserName");
+							String sender = nodelist1.item(0).getTextContent();
+							
+							NodeList nodelist2 = root.getElementsByTagName("Content");
+							String content = nodelist2.item(0).getTextContent();
+							System.out.println("Sender is " + sender);
+							System.out.println("Content is " + content);
+							
+							//check if have key_ty USER_RESPONSE in DB, if no, there is no login request, if yes, update the user response in db
+							Optional<TaMasterCd> opt4 = tmc.findById("USER_RESPONSE");
+							if(opt4.isPresent()) {
+								TaMasterCd enti = opt4.get();
+								content = content.trim().toUpperCase();
+								enti.setCd(content);
+								enti.setDecode(sender);
+								tmc.saveAndFlush(enti);
+							}
+							else {
+								System.out.println("ignore the msg");
+							}
+							
+						} catch (Exception e) {
+							e.printStackTrace();
+						}
+						result = "ok";
+					}
+					else {
+						System.out.println("Not support method:"+ method);
+						result = "Not support method:"+ method;
+					}
+				}
+				else {
+					System.out.println("No callback config, ignore it");
+				}
+			}
+			else {
+				System.out.println("wx login verify indicator is not Y");
+			}
+		}
+		else {
+			System.out.println("No wx login verify");
+		}
+		
+		return result;
+	}
+}

--- a/src/main/java/hqr/o365/service/SendLoginMsgToWx.java
+++ b/src/main/java/hqr/o365/service/SendLoginMsgToWx.java
@@ -1,0 +1,93 @@
+package hqr.o365.service;
+
+import java.util.Date;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
+
+import hqr.o365.dao.TaMasterCdRepo;
+import hqr.o365.domain.TaMasterCd;
+
+@Service
+public class SendLoginMsgToWx {
+	
+	private RestTemplate restTemplate = new RestTemplate();
+	
+	@Autowired
+	private TaMasterCdRepo tmc;
+	
+	public boolean sendMsg() {
+		boolean status = false;
+		
+		String corpId = "";
+		String corpSecret = "";
+		String agentId = "";
+		
+		Optional<TaMasterCd> opt1 = tmc.findById("WX_CORPID");
+		Optional<TaMasterCd> opt2 = tmc.findById("WX_CORPSECRET");
+		Optional<TaMasterCd> opt3 = tmc.findById("WX_AGENTID");
+		if(opt1.isPresent()&&opt2.isPresent()&&opt3.isPresent()) {
+			corpId = opt1.get().getCd();
+			corpSecret = opt2.get().getCd();
+			agentId = opt3.get().getCd();
+		}
+
+		if(corpId!=null&&corpSecret!=null&&agentId!=null&&!"".equals(corpId)&&!"".equals(corpSecret)&&!"".equals(agentId)) {
+			String endpoint1 = "https://qyapi.weixin.qq.com/cgi-bin/gettoken?corpid="+corpId+"&corpsecret="+corpSecret;
+			HttpHeaders headers1 = new HttpHeaders();
+			String body1="";
+			HttpEntity<String> requestEntity1 = new HttpEntity<String>(body1, headers1);
+			try {
+				ResponseEntity<String> response1 = restTemplate.exchange(endpoint1, HttpMethod.GET, requestEntity1, String.class);
+				JSONObject jo = JSON.parseObject(response1.getBody());
+		    	String errcode = jo.get("errcode").toString();
+		    	if("0".equals(errcode)) {
+		    		String token = (String)jo.get("access_token");
+		    		
+					String endpoint2 = "https://qyapi.weixin.qq.com/cgi-bin/message/send?access_token="+token+"&debug=1";
+					HttpHeaders headers2 = new HttpHeaders();
+					headers2.setContentType(MediaType.APPLICATION_JSON);
+					String content = "用户请求登录O365管理系统，如果批准请在60秒内回复Y，如果这不是你已知的登录请求那么可能你的密码已泄露，请忽略或回复N";
+					//agentId=1000002
+					String body2 = "{\"touser\": \"@all\",\"msgtype\" : \"text\",\"agentid\" : "+agentId+",\"text\" : {\"content\" : \""+content+"\"},\"enable_duplicate_check\" : 1, \"duplicate_check_interval\" : 3}";
+
+					HttpEntity<String> requestEntity2 = new HttpEntity<String>(body2, headers2);
+					ResponseEntity<String> response2 = restTemplate.exchange(endpoint2, HttpMethod.POST, requestEntity2, String.class);
+		    		
+					JSONObject jo2 = JSON.parseObject(response2.getBody());
+			    	String errcode2 = jo2.get("errcode").toString();
+			    	if("0".equals(errcode2)) {
+			    		//init the user reply keyty in DB
+			    		TaMasterCd enti = new TaMasterCd();
+			    		enti.setKeyTy("USER_RESPONSE");
+			    		enti.setLastUpdateId("o365");
+			    		enti.setLastUpdateDt(new Date());
+			    		tmc.saveAndFlush(enti);
+			    		
+			    		System.out.println("msg push to user successfully, wait 60s for user reply");
+			    		status = true;
+			    	}
+			    	else {
+			    		System.out.println("failed to push the msg "+jo2.get("errmsg"));
+			    	}
+		    	}
+			}
+			catch (Exception e) {
+				System.out.println("failed to push the msg2 "+e);
+			}
+		}
+
+		return status;
+	}
+	
+}

--- a/src/main/resources/ta_master_cd.sql
+++ b/src/main/resources/ta_master_cd.sql
@@ -62,4 +62,13 @@ insert into ta_master_cd(key_ty,cd,decode,start_dt,end_dt,create_dt,last_update_
 --update mask info
 update ta_office_info set mask_app_id='*****',mask_secret_id='*****';
 
+--update wx info
+insert into ta_master_cd(key_ty,cd,decode,start_dt,end_dt,create_dt,last_update_id,last_update_dt) values ('WX_CALLBACK_IND','N','Y to enable the login verify on wx',sysdate,null,sysdate,'o365',sysdate);
+insert into ta_master_cd(key_ty,cd,decode,start_dt,end_dt,create_dt,last_update_id,last_update_dt) values ('WX_CALLBACK_TOKEN','','callback token',sysdate,null,sysdate,'o365',sysdate);
+insert into ta_master_cd(key_ty,cd,decode,start_dt,end_dt,create_dt,last_update_id,last_update_dt) values ('WX_CORPID','','corp id',sysdate,null,sysdate,'o365',sysdate);
+insert into ta_master_cd(key_ty,cd,decode,start_dt,end_dt,create_dt,last_update_id,last_update_dt) values ('WX_CORPSECRET','','corp secret',sysdate,null,sysdate,'o365',sysdate);
+insert into ta_master_cd(key_ty,cd,decode,start_dt,end_dt,create_dt,last_update_id,last_update_dt) values ('WX_AGENTID','','corp agent id',sysdate,null,sysdate,'o365',sysdate);
+insert into ta_master_cd(key_ty,cd,decode,start_dt,end_dt,create_dt,last_update_id,last_update_dt) values ('WX_CALLBACK_AESKEY','','callback aeskey',sysdate,null,sysdate,'o365',sysdate);
+
+
 commit;

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -35,7 +35,7 @@
 		    </div>
 		</div>
 	</div>
-	<div data-options="region:'south',border:false" style="height:25px;background:#A9FACD" >Powered by hqr - O365 v1.5.1 </div>
+	<div data-options="region:'south',border:false" style="height:25px;background:#A9FACD" >Powered by hqr - O365 v1.5.2 </div>
 	<div id="acc" class="easyui-tabs" data-options="region:'center'">
 		<div title="首页" style="padding:10px">
 			<h2>欢迎来到O365管理系统，你可以使用它来方便的管理多个Office全局</h2>


### PR DESCRIPTION
1. 在配置页面加入On/Off按钮用于显示/隐藏应用ID和密钥
2. 在配置页面加入生成报告按钮允许对于单个全局生成报告
3. 登录增强，与微信集成，登录时会收到登录请求，微信回复后方可允许此次登录（此功能默认关闭）
PS: 在没有配置好以下变量前请勿将WX_CALLBACK_IND设置为Y，否则将无法登录
WX_CALLBACK_TOKEN 
WX_CORPID         
WX_CORPSECRET     
WX_AGENTID        
WX_CALLBACK_AESKEY
调试参考
https://open.work.weixin.qq.com/wwopen/devtool/interface/combine